### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/phase_rtabmap_ros2
+script_dir=$base/lib/phase_rtabmap_ros2
 [install]
-install-scripts=$base/lib/phase_rtabmap_ros2
+install_scripts=$base/lib/phase_rtabmap_ros2


### PR DESCRIPTION
dash separating is being deprecated for underscores. This gives a warning, which causes docker builds to fail